### PR TITLE
Find all roots in the range [1,1000]

### DIFF
--- a/Confinement functions/MSDspherical.m
+++ b/Confinement functions/MSDspherical.m
@@ -3,10 +3,12 @@ fun2 = @(x) (x.^2-2).*sin(x)+2*x.*(cos(x));
 zerovalues = zeros(100,1);
 
 for i = 2:1:1000
-zerovalues(i-1) = fzero(fun2,i);
+  % Find roots at sign changes
+  if fun2(i-1) * fun2(i) < 0
+    zerovalues(i-1) = fzero(fun2,[i-1,i]);
+  end
 end
 
-zerovalues = uniquetol(zerovalues,1e-8);
 tau = r.^2./D;
 zerovalues = zerovalues(zerovalues>0);
 start = numel(zerovalues)+1;


### PR DESCRIPTION
When looking at the code for fitting within a confined sphere I found that not all the roots of the derivative of the spherical Bessal function are evaluated.

Try:
```
zerovalues = zeros(1000,1);

for i = 2:1:1000
  % Finds 306 roots
  zerovalues(i-1) = fzero(fun2,i);
end

zerovalues = uniquetol(zerovalues,1e-8);
zerovalues = zerovalues(zerovalues>0);

plot(diff(zerovalues))
```

verses:

```
zerovalues = zeros(1000,1);

for i = 2:1:1000
  % Find roots at sign changes
  % Finds 318 roots
  if fun2(i-1) * fun2(i) < 0
    zerovalues(i-1) = fzero(fun2,[i-1,i]);
  end
end

zerovalues = zerovalues(zerovalues>0);

plot(diff(zerovalues))
```

In the original method the first missing root is the 80th root. So this is unlikely to change the infinite summation for most arguments of (r, t, D).

Thanks for the excellent resources on anaDDA.
