### PR TITLE
Correct plotting for multiple species

### DIFF
--- a/Plotting functions/plotlog.m
+++ b/Plotting functions/plotlog.m
@@ -1,7 +1,7 @@
 function plotlog(framenr,parameters,D, input,bootstrapparamstd,frametimerange,singlefigure,locerrorparameter)
 load(fullfile(fileparts(mfilename('fullpath')),'layoutparameters.mat'))
-maxDfree = max(parameters(:,4),parameters(:,5));
-maxrangeD = -log(1e-22)*maxDfree;
+Dfree = max(parameters(:,4),parameters(:,5));
+maxrangeD = -log(1e-22)*max(Dfree);
 rangeD =maxrangeD/(input.precision*2):maxrangeD/input.precision:maxrangeD;
 D = D(1,D(2,:)==framenr);
 logrange = 10.^(min(layoutparameters.range):0.01:max(layoutparameters.range));% Converted to x values
@@ -45,7 +45,7 @@ for ii = 1:size(parameters)
     framescombined = framescombined./sum(framescombined);
     framescombined = c*framescombined(:,framenr);
 
-    func = @(x) interp1(framescombined,x,'spline');
+    func = @(x) interp1(framescombined,x,'spline',0);
     lograngetrue = (logrange-rangeD(1))*framenr./(rangeD(3)-rangeD(2))+1;
     logpdf = framenr*logrange.*func(lograngetrue)/(0.44*(rangeD(3)-rangeD(2))/0.01);
     % for i = 1:numel(lograngetrue)-1


### PR DESCRIPTION
If the second species has a larger Dfree than the first species then the range is computed incorrectly as matlab silently expands the range using an array input using the first column:
```matlab
p = [0 0 0 1 1; 0 0 0 2 2];
input.precision = 2^16;
maxDfree = max(p(:,4),p(:,5));
maxrangeD = -log(1e-22)*maxDfree;
rangeD =maxrangeD/(input.precision*2):maxrangeD/input.precision:maxrangeD;
rangeD(end)

Dfree = max(p(:,4),p(:,5));
maxrangeD = -log(1e-22)*max(Dfree);
rangeD =maxrangeD/(input.precision*2):maxrangeD/input.precision:maxrangeD;
rangeD(end)
```

This change also sets the value outside the spline interpolation to zero. Assuming the range computed from the input Dfree will cover the data allows computation of a full PDF. However the range for plotting is fixed and may exceed the computed max range. I have observed occasions where the end of the PDF has a trend that when extrapolated using the cubic spline results in very large positive or negative values. The simplest solution is to assume the PDF outside the computed range is zero. This is an adequate solution for plotting.